### PR TITLE
Two simple makegreen fixes.

### DIFF
--- a/plugin/makegreen.vim
+++ b/plugin/makegreen.vim
@@ -20,7 +20,9 @@ set cpo&vim
 function s:RunMake() "{{{1
   silent! w
   let s:old_sp = &shellpipe
-  set shellpipe=&> "quieter make output
+  if has('unix')
+    set shellpipe=&> "quieter make output
+  endif
   silent! make %
   let &shellpipe = s:old_sp
 

--- a/plugin/makegreen.vim
+++ b/plugin/makegreen.vim
@@ -47,6 +47,9 @@ function s:GetFirstError()
       break
     endif
   endfor
+  if ! error['valid']
+    return ''
+  endif
   let error_message = substitute(error['text'], '^ *', '', 'g')
   let error_message = substitute(error_message, "\n", ' ', 'g')
   let error_message = substitute(error_message, "  *", ' ', 'g')


### PR DESCRIPTION
Hi,

I'm trying to use makegreen on Windows to run Python unit tests. I ran into two problems:
1. shellpipe was being set to something that's specific to bash so it fails on Windows (I'm not using Cygwin). I modified the plugin to only set shellpipe if Vim has the 'unix' feature.
2. When there are no errors, I was still getting a red bar. That's because the GetFirstError was assuming that the last line from the quickfix list is always an error. So I was seeing a red bar that said "OK" in it. I added a simple if statement checking to see if the last line is not a valid error to prevent that.

Thanks.
