### PR TITLE
Jump to error in an open window containing it, if possible.

### DIFF
--- a/plugin/makegreen.vim
+++ b/plugin/makegreen.vim
@@ -29,7 +29,7 @@ function MakeGreen(...) "{{{1
   endif
 
   silent! w " TODO: configuration option?
-  silent! exec "make " . make_args
+  silent! exec "make! " . make_args
 
   redraw!
 
@@ -83,4 +83,5 @@ endif
 let &cpo = s:save_cpo
 unlet s:save_cpo
 
+autocmd QuickFixCmdPost * nested cwindow | cfirst | cclose
 " vim:set sw=2 sts=2:

--- a/plugin/makegreen.vim
+++ b/plugin/makegreen.vim
@@ -20,7 +20,9 @@ set cpo&vim
 function s:RunMake() "{{{1
   silent! w
   let s:old_sp = &shellpipe
-  set shellpipe=&> "quieter make output
+  if has('unix')
+    set shellpipe=&> "quieter make output
+  endif
   silent! make %
   let &shellpipe = s:old_sp
 

--- a/plugin/makegreen.vim
+++ b/plugin/makegreen.vim
@@ -47,6 +47,9 @@ function s:GetFirstError()
       break
     endif
   endfor
+  if ! error['valid']
+    return ''
+  endif
   let error_message = substitute(error['text'], '^ *', '', 'g')
   let error_message = substitute(error_message, "\n", ' ', 'g')
   let error_message = substitute(error_message, "  *", ' ', 'g')

--- a/plugin/makegreen.vim
+++ b/plugin/makegreen.vim
@@ -17,8 +17,8 @@ let g:makegreen_loaded = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
-hi GreenBar term=reverse ctermfg=white ctermbg=green guifg=white guibg=green
-hi RedBar   term=reverse ctermfg=white ctermbg=red guifg=white guibg=red
+hi GreenBar term=reverse ctermfg=white ctermbg=darkgreen guifg=white guibg=darkgreen
+hi RedBar   term=reverse ctermfg=white ctermbg=darkred guifg=white guibg=darkred
 
 function MakeGreen(...) "{{{1
   let arg_count = a:0


### PR DESCRIPTION
I work with 2 windows open, one with the tests, one with the code.

When I run the tests when in the code window I don't like the way that :make changed the buffer of the code-window to the buffer of the tests, while it is already available in another window. So I end up with 2 windows both with the tests open and having to switch buffers back to the code.

This patch makes the jump to the already open window if available, and falls back to the old bufferswitch behaviour if that window is not available.

If there is a smarter way to fix this outside of makegreen.vim, I'd love to know that.
