### PR TITLE
remove mapping and create MakeGreen command

### DIFF
--- a/plugin/makegreen.vim
+++ b/plugin/makegreen.vim
@@ -22,14 +22,13 @@ hi RedBar   term=reverse ctermfg=white ctermbg=red guifg=white guibg=red
 
 function MakeGreen(...) "{{{1
   let arg_count = a:0
-  if arg_count
-    let make_args = a:1
-  else
-    let make_args = '%'
-  endif
 
   silent! w " TODO: configuration option?
-  silent! exec "make " . make_args
+  if arg_count
+    silent! exec "make " . a:1
+  else
+    silent! exec "make"
+  endif
 
   redraw!
 
@@ -72,7 +71,7 @@ function s:Bar(type, msg)
   echohl None
 endfunction
 
-:command MakeGreen :call MakeGreen()
+:command -nargs=* MakeGreen :call MakeGreen(<q-args>)
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/plugin/makegreen.vim
+++ b/plugin/makegreen.vim
@@ -23,11 +23,17 @@ hi RedBar   term=reverse ctermfg=white ctermbg=red guifg=white guibg=red
 function MakeGreen(...) "{{{1
   let arg_count = a:0
 
+  if exists("g:makegreen_stay_on_file") && g:makegreen_stay_on_file
+    let make_command = "make!"
+  else
+    let make_command = "make"
+  endif
+
   silent! w " TODO: configuration option?
   if arg_count
-    silent! exec "make " . a:1
+    silent! exec make_command . " " . a:1
   else
-    silent! exec "make"
+    silent! exec make_command
   endif
 
   redraw!

--- a/plugin/makegreen.vim
+++ b/plugin/makegreen.vim
@@ -72,6 +72,7 @@ function s:Bar(type, msg)
   echohl None
 endfunction
 
+:command MakeGreen :call MakeGreen()
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/plugin/makegreen.vim
+++ b/plugin/makegreen.vim
@@ -72,13 +72,6 @@ function s:Bar(type, msg)
   echohl None
 endfunction
 
-" }}}1
-" Mappings" {{{1
-
-if !hasmapto('MakeGreen')
-  map <unique> <silent> <Leader>t :call MakeGreen()<cr>
-endif
-" }}}1
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
I think MakeGreen should be :make with the green bar, so I removed the key mapping (to avoid conflicts with other user's custom mappings) and created the command :MakeGreen that accepts exactly the arguments of :make.

I know that everyone who actually use MakeGreen rely on plugin's mapping, but I think that this kind of customization should be deferred to the user's .vimrc.
