### PR TITLE
added vim-dispatch support

### DIFF
--- a/plugin/makegreen.vim
+++ b/plugin/makegreen.vim
@@ -24,9 +24,17 @@ function MakeGreen(...) "{{{1
   let arg_count = a:0
 
   if exists("g:makegreen_stay_on_file") && g:makegreen_stay_on_file
-    let make_command = "make!"
-  else
-    let make_command = "make"
+    if exists(":Make")
+        let make_command = "Make!"
+      else
+        let make_command = "make!"
+      endif
+    else
+      if exists(":Make")
+        let make_command = "Make"
+      else
+        let make_command = "make"
+    endif
   endif
 
   silent! w " TODO: configuration option?


### PR DESCRIPTION
uses :Make instead of :make to use tmux window, if the tpope/vim-dispatch plugin is present
